### PR TITLE
Workaround for firefox to enable download button navigation.

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
 
         <p>This is an open source project licensed under Apache Public License 2.0. Some components are licensed under GNU General Public License (GPL) 2.0 or later. If you think we did something great, consider <a href="donate.html">making a donation</a>.</p>
 
-        <button class="download-btn" type="button"><a id="download-button-home" href="download.html"><span>Download</span></a></button>
+        <button class="download-btn" type="button" onClick="location.href='download.html'"><a id="download-button-home" href="download.html"><span>Download</span></a></button>
 
         <h2>What's New</h2>
               <ul>


### PR DESCRIPTION
Download button link cannot be clicked with Firefox because this style of link (inside buttton) is invalid.

This fix is minimal modification to enable download navigation.

Refs:
https://stackoverflow.com/questions/35493800
https://stackoverflow.com/questions/16280684