### PR TITLE
Trouble shooting for customize kernel

### DIFF
--- a/documentation/customize_kernel.html
+++ b/documentation/customize_kernel.html
@@ -66,9 +66,9 @@
                       <code class="code-shell">. build/envsetup.sh; lunch android_x86_64-userdebug</code><br>
                       <code class="code-shell">make -C kernel O=$OUT/obj/kernel ARCH=x86 menuconfig<br></code>
                     </span></div>
-		    <p>If you get an error message <tt>Unknown option: -C</tt>, change <tt>make</tt> to <tt>/usr/bin/make</tt>.</p>
+                    <p>If you get an error message <tt>Unknown option: -C</tt>, change <tt>make</tt> to <tt>/usr/bin/make</tt>.</p>
                     <p>The generated config is <tt>$OUT/obj/kernel/.config</tt>. Copy it to where you want it to be.</p>
-		    <p>DO NOT issue <tt>make menuconfig</tt> in the kernel/ directory directly. If you do so, the build rules may be broken. In this case, try this way to recover it (on the top of android-x86 tree):</p>
+                    <p>DO NOT issue <tt>make menuconfig</tt> in the kernel/ directory directly. If you do so, the build rules may be broken. In this case, try this way to recover it (on the top of android-x86 tree):</p>
                     <div class="code-snippet"><span style="color:#d1d1d1">
                       <code class="code-shell">make -C kernel distclean<br></code>
                       <code class="code-shell">rm -rf $OUT/obj/kernel<br></code>

--- a/documentation/customize_kernel.html
+++ b/documentation/customize_kernel.html
@@ -66,8 +66,9 @@
                       <code class="code-shell">. build/envsetup.sh; lunch android_x86_64-userdebug</code><br>
                       <code class="code-shell">make -C kernel O=$OUT/obj/kernel ARCH=x86 menuconfig<br></code>
                     </span></div>
+		    <p>If you get an error message <tt>Unknown option: -C</tt>, change <tt>make</tt> to <tt>/usr/bin/make</tt>.</p>
                     <p>The generated config is <tt>$OUT/obj/kernel/.config</tt>. Copy it to where you want it to be.</p>
-                    <p>DO NOT issue <tt>make menuconfig</tt> in the kernel/ directory directly. If you do so, the build rules may be broken. In this case, try this way to recover it (on the top of android-x86 tree):</p>
+		    <p>DO NOT issue <tt>make menuconfig</tt> in the kernel/ directory directly. If you do so, the build rules may be broken. In this case, try this way to recover it (on the top of android-x86 tree):</p>
                     <div class="code-snippet"><span style="color:#d1d1d1">
                       <code class="code-shell">make -C kernel distclean<br></code>
                       <code class="code-shell">rm -rf $OUT/obj/kernel<br></code>


### PR DESCRIPTION
When customizing kernel for Oreo-x86, I meet an error message for the make command

> Unknown option: -C

After googling, I find another poor guy who got the same error message as I: [https://askubuntu.com/questions/1093567/make-unknown-option-on-any-command-after-installing-adroid-x86-build-tools](https://askubuntu.com/questions/1093567/make-unknown-option-on-any-command-after-installing-adroid-x86-build-tools)

Probably the reason is that the aosp's version of make doesn't support -C.

Nevertheless, using `/usr/bin/make` instead of `make` can perfectly solve this problem.