### PR TITLE
Fix jide url in analytics documentation

### DIFF
--- a/documentation/analytics.html
+++ b/documentation/analytics.html
@@ -44,7 +44,7 @@
 
                 <p>The core developers will be granted the permission to read the data. Suggestions to improve the Analytics program are welcome.</p>
                 <p>The analytics code has been checked in the marshmallow-x86 branch and included in the <a href="http://www.android-x86.org/releases/releasenote-6-0-rc2">6.0-rc2 release</a>.<br><br>
-                Most of the analytics code is contributed by <a href="http://jide.com/">Jide Technology Ltd</a> and licensed under <a href="https://www.apache.org/licenses/LICENSE-2.0">Apache License, Version 2.0.</a></p>
+                Most of the analytics code is contributed by <a href="http://www.jide.com/">Jide Technology Ltd</a> and licensed under <a href="https://www.apache.org/licenses/LICENSE-2.0">Apache License, Version 2.0.</a></p>
 
         </section>
 


### PR DESCRIPTION
Chrome and Firefox can't figure http://jide.com.

Test: manually.