### PR TITLE
Add step to enable network in VirtualBox if can't connect to network

### DIFF
--- a/documentation/virtualbox.html
+++ b/documentation/virtualbox.html
@@ -85,7 +85,7 @@
 			    </ol>
                     <li><span class="bold">[Storage]</span> Find the first "Empty" item (this should have an icon of a CD). In the Attributes, click on the CD icon with a small down arrow, and pick "Choose Optical Virtual Disk File...". Specify the Android-x86 ISO that you downloaded.</li>
                     <li><span class="bold">[Audio]</span> Intel HD Audio seems to be natively supported in Android-x86.</li>
-                    <li><span class="bold">[Network]</span> By default, your installation of Android-x86 will be able to automatically connect to the internet. If you do not want this, uncheck Enable Network Adapter under the Adapter 1 tab.</li>
+                    <li><span class="bold">[Network]</span> By default, your installation of Android-x86 will be able to automatically connect to the internet. If not, you can try to enable WiFi in Settings/Network & Internet, and connect to showing VirtWifi. If you do not want to connect to the internet in VirtualBox, uncheck Enable Network Adapter under the Adapter 1 tab.</li>
                   </ul>
                 </p>
                 <h3>Install</h3>


### PR DESCRIPTION
After installing android-x86 built from pie-x86 to VirtualBox with the
default network configuration - NAT, the android-x86 can't connect to
network. In this occasion, we can enable WiFi, and connect to showing
VirtWifi to enable network for android-x86.

Test: Ubuntu 20.04 and VirtualBox 6.1.6_Ubuntu r137129