### PR TITLE
Add section to enable adb via network for vbox

### DIFF
--- a/documentation/virtualbox.html
+++ b/documentation/virtualbox.html
@@ -177,6 +177,16 @@
               Then type exit to enter Android.
             </p>
 
+            <h3>Debug with adb</h3>
+            <p>This section describes the way to debug Android with adb via network.</p>
+            <p>If we want to debug with adb via network, we should ensure the ip of vbox can be accessed by host machine. So we should change the Network Adapter type of vbox to Bridged Adapter. After starting the android-x86, we should follow the above Settings/[Network] section to ensure the network of android-x86 is enabled, and enable USB debugging in Settings/System/Developer Options. Then we can get the device ip from Settings/System/About tablet/IP address. For example, if we see the ip address is 192.168.0.116, then we can use following command to connect android-x86 in vbox from host machine.
+            <div class="code-snippet"><span style="color:#d1d1d1">
+                <code class="code-shell">adb connect 192.168.0.116</code>
+                </span>
+            </div>
+            Then you can use adb command to debug android-x86 such as get log, and dump system information.
+            </p>
+
 	<h3>References</h3>
     <ol class="refs">
 	<li id="ref1"></a><sup>^ <a href="#ref1_a" onclick="scroller('ref1_a'); return false">a</a> <a href="#ref1_b" onclick="scroller('ref1_b'); return false">b</a></sup> VirtualBox currently <a href="https://www.virtualbox.org/manual/ch04.html#additions-linux" target="_blank">has no Guest Additions for Android.</a></li>


### PR DESCRIPTION
It will help to debug system with adb via network for vbox.

Test with Ubuntu 20.04 and VirtualBox 6.1.6_Ubuntu r137129, and the following is the test steps and result:

```
android-x86$ adb connect 192.168.0.116
connected to 192.168.0.116:5555
android-x86$ adb devices
List of devices attached
192.168.0.116:5555	device
android-x86$ adb logcat
--------- beginning of main
06-11 16:31:27.450  1073  1073 I SELinux : SELinux: Loaded service_contexts from:
06-11 16:31:27.450  1071  1071 I SELinux : SELinux: Loaded service_contexts from:
06-11 16:31:27.451  1073  1073 I SELinux :     /vndservice_contexts
06-11 16:31:27.451  1071  1071 I SELinux :     /plat_service_contexts
06-11 16:31:27.451  1071  1071 I SELinux :     /vendor_service_contexts
06-11 16:31:20.300  1070  1070 W auditd  : type=2000 audit(0.0:1): state=initialized audit_enabled=0 res=1
06-11 16:31:27.476  1072  1072 I hwservicemanager: hwservicemanager is ready now.
06-11 16:31:16.234  1070  1070 W auditd  : type=1403 audit(0.0:2): auid=4294967295 ses=4294967295 lsm=selinux res=1
06-11 16:31:16.235     1     1 I init    : type=1400 audit(0.0:3): avc: denied { search } for name="/" dev="tmpfs" ino=6648 scontext=u:r:kernel:s0 tcontext=u:object_r:tmpfs:s0 tclass=dir permissive=1
06-11 16:31:16.235     1     1 I init    : type=1400 audit(0.0:4): avc: denied { read } for name="plat_file_contexts" dev="tmpfs" ino=7235 scontext=u:r:kernel:s0 tcontext=u:object_r:tmpfs:s0 tclass=file permissive=1
06-11 16:31:16.235     1     1 I init    : type=1400 audit(0.0:5): avc: denied { read } for name="vendor" dev="tmpfs" ino=7255 scontext=u:r:kernel:s0 tcontext=u:object_r:tmpfs:s0 tclass=lnk_file permissive=1
06-11 16:31:16.235  1035  1035 I loop1   : type=1400 audit(0.0:6): avc: denied { read } for path="/sfs/system.img" dev="loop0" ino=1 scontext=u:r:kernel:s0 tcontext=u:object_r:unlabeled:s0 tclass=file permissive=1
06-11 16:31:16.236  1031  1031 I loop0   : type=1400 audit(0.0:7): avc: denied { read } for path="/mnt/system.sfs" dev="sr0" ino=1897 scontext=u:r:kernel:s0 tcontext=u:object_r:unlabeled:s0 tclass=file permissive=1

```