### PR TITLE
Fix typo of AOSP

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
       </div>
 
       <a href="donate.html"><img class="coffee" border="0" src="Android-x86_Coffee_Banner.jpg"></img></a>
-      <p>This is a project to port <a href="https://source.android.com">Android open source project</a> to x86 platform, formerly known as "<a href="https://code.google.com/archive/p/patch-hosting-for-android-x86-support/">patch hosting for android x86 support</a>".
+      <p>This is a project to port <a href="https://source.android.com">Android Open Source Project</a> to x86 platform, formerly known as "<a href="https://code.google.com/archive/p/patch-hosting-for-android-x86-support/">patch hosting for android x86 support</a>".
         The original plan is to host different patches for android x86 support from open source community. A few months after we created the project, we found out that we could do much more than just hosting patches. So we decide to create our code base
         to provide support on different x86 platforms, and set up a git server to host it.</p>
 


### PR DESCRIPTION
`Android open source project` -> `Android Open Source Project`.