### PR TITLE
Fix typo in VirtualBox documentation

### DIFF
--- a/documentation/virtualbox.html
+++ b/documentation/virtualbox.html
@@ -125,7 +125,7 @@
                 Here is a note from David when using fdisk:
                 <ol>
                 <li>Create a new virtual machine with a hard disk.
-                <li>Launch the Live ISO in Debug mode (I used android-x86-2.2-generic.iso) to get the commend prompt.
+                <li>Launch the Live ISO in Debug mode (I used android-x86-2.2-generic.iso) to get the command prompt.
                 <li>"fdisk /dev/sda", then type:
                   <ol>
                       <li>"n" (new partition)


### PR DESCRIPTION
It was "commend prompt" and it's now "command prompt".